### PR TITLE
Update home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,23 +11,16 @@ og:
         <h2 class="title is-4">
            Get/Deliver Food (still happening!)
         </h2>
-
+     
         <p>
-            We’re excited to have two delivery partnerships available in the Denver metro area: one with Joy’s Kitchen in Lakewood,
-            and one with Growing Home in Westminster.
+            RMMAN is still delivering food to families in and around Denver, to learn more about what we do visit our <a href="https://linktr.ee/rmmutualaid" target="_blank" rel="noopener noreferrer">linktree page.</a>
         </p>
-
-        <p>
-            {% include btn.html href="/volunteer/delivery/" class="is-success is-large is-fullwidth" text="Learn More" %}
-        </p>
-
 
         <figure class="image is-128x128" style="margin: 0 auto">
             <img src="/assets/brand/rmman-logo-simple.jpg">
         </figure>
         <p>
-            RMMAN is no longer operating. There is still mutual aid happening in the Rockies.
-            Visit <a href="https://twitter.com/AidMonday">Mutual Aid Mondays</a> and connect with folks there.
+     
             All the code for this site is available on <a href="https://github.com/Rocky-Mountain-Mutual-Aid-Network/rmman.org"
                 target="_blank" rel="noopener noreferrer">GitHub.com</a>
             You can review our donation history over at <a href="https://opencollective.com/rmman">Open Collective</a> (if you


### PR DESCRIPTION
At the last RMMAN coordination meeting we discussed that the website needed some slight changes to the wording on the home page and a link to our linktree which we've been using a lot more recently. I offered to make the changes since I already have a github account. This is a very small change. I've only removed the bit about us no longer operating (has confused a few people) and added the linktree. Happy to make any changes needed before you merge. Thanks!